### PR TITLE
Update mount options configuration syntax to support newer versions of Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure("2") do |config|
   # config.vm.network :public_network
 
   # Lucky people can enable nfs but they will get permission errors https://groups.google.com/forum/?fromgroups=#!topic/vagrant-up/-J3UEqYXveA
-  config.vm.synced_folder ".", "/vagrant", :extra => 'dmode=777,fmode=777'
+  config.vm.synced_folder ".", "/vagrant", :mount_options => ['dmode=777','fmode=777']
 
   config.vm.provider :virtualbox do |vb|
   


### PR DESCRIPTION
Great job with the Vagrant environment, saved me a lot of time! :)

While setting up I however noticed that the mount options configuration syntax has changed (probably around Vagrant 1.3.0).

Here's a quick patch for it, tested and just now set it up with Vagrant 1.4.0.
